### PR TITLE
Update targets

### DIFF
--- a/MimeTypes/MimeTypes.csproj
+++ b/MimeTypes/MimeTypes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard1.0</TargetFramework>
+        <TargetFrameworks>netstandard1.0;netstandard2.0;net6.0</TargetFrameworks>
         <RootNamespace>Mainwave.MimeTypes</RootNamespace>
         <PackageId>Mainwave.MimeTypes</PackageId>
         <Title>MimeTypes</Title>


### PR DESCRIPTION
This targets netstandard.20 and net6.0 to make it easier to not include NETStandard.Library 1.6.1 to resolve some included CVEs.

Resolves #51 